### PR TITLE
fix(ci): upgrade to Node 24 for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
         if: steps.check.outputs.exists == 'false'
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
 
       - name: Setup Bun


### PR DESCRIPTION
## Summary
- Upgrade `setup-node` from Node 22 to Node 24
- Node 22 ships npm 10.x which doesn't fully support OIDC handshake — provenance gets signed but registry treats publish as anonymous (404)
- Node 24 ships npm >= 11.5.1 with full OIDC trusted publishing support

## References
- https://medium.com/@kenricktan11/npm-trusted-publishers-the-weird-404-error-and-the-node-js-24-fix-a9f1d717a5dd
- https://github.com/npm/cli/issues/8976

Fixes #45