### PR TITLE
chore(hooks): add biome pre-push hook (#54)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Runs Biome lint + format checks before pushing.
+# Bypass with: git push --no-verify
+set -e
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "error: bun not found on PATH — install bun or use --no-verify to bypass" >&2
+  exit 1
+fi
+
+bun run check

--- a/README.md
+++ b/README.md
@@ -143,6 +143,22 @@ npm run test:unit:storybook
 npm run lint
 ```
 
+### Git hooks
+
+A pre-push hook runs Biome before every push so formatting/lint issues fail locally instead of on CI. The hook lives in `.githooks/pre-push` and is registered automatically the first time you run `bun install` (via the `prepare` script, which sets `core.hooksPath`).
+
+If the hook doesn't activate for some reason:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+To skip the hook for a single push (use sparingly):
+
+```bash
+git push --no-verify
+```
+
 ## Project Structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "format:check": "biome format .",
     "format:tailwind": "rustywind --write src/",
     "check": "biome check .",
+    "prepare": "git config core.hooksPath .githooks || true",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",


### PR DESCRIPTION
## Summary
This PR adds a native git pre-push hook that runs `bun run check` (biome lint + format) locally and blocks the push if the repo isn't clean.

## Changes
- **Git Hooks**:
  - Added `.githooks/pre-push` to run `bun run check` locally.
  - Automated hook setup via `prepare` script in `package.json`.
  - Documented setup in `README.md`.

Closes #54